### PR TITLE
Store Encrypted kind 4

### DIFF
--- a/UI/_setup.test.ts
+++ b/UI/_setup.test.ts
@@ -6,7 +6,7 @@ import { UI_Interaction_Event } from "./app_update.tsx";
 export const testEventBus = new EventBus<UI_Interaction_Event>();
 export const data = new Map();
 export const testEventsAdapter: EventsAdapter = {
-    delete() {},
+    async remove() {},
     filter: async (f) => {
         const events = [];
         for (const [k, v] of data) {

--- a/UI/app.tsx
+++ b/UI/app.tsx
@@ -122,11 +122,7 @@ async function initProfileSyncer(
         myPublicKey,
         pool,
     );
-    // database.syncNewDirectMessageEventsOf(
-    //     accountContext,
-    //     messageStream,
-    // );
-    // database.syncEvents(_=>true, messageStream)
+
     (async () => {
         for await (const msg of messageStream) {
             if (msg.res.type == "EVENT") {

--- a/UI/app.tsx
+++ b/UI/app.tsx
@@ -126,7 +126,15 @@ async function initProfileSyncer(
     //     accountContext,
     //     messageStream,
     // );
-    database.syncEvents(_=>true, messageStream)
+    // database.syncEvents(_=>true, messageStream)
+    (async () => {
+        for await (const {event, url} of messageStream) {
+            const err = await database.addEvent(event)
+            if(err instanceof Error) {
+                console.log(err)
+            }
+        }
+    })();
 
     // Sync my profile events
     const profilesSyncer = new ProfilesSyncer(database, pool);

--- a/UI/app.tsx
+++ b/UI/app.tsx
@@ -205,7 +205,6 @@ export class App {
 
     initApp = async (accountContext: NostrAccountContext, pool: ConnectionPool) => {
         console.log("App.initApp");
-        this.allUsersInfo.addEvents(this.database.events);
         {
             ///////////////////////////////////
             // Add relays to Connection Pool //

--- a/UI/app.tsx
+++ b/UI/app.tsx
@@ -128,10 +128,10 @@ async function initProfileSyncer(
     // );
     // database.syncEvents(_=>true, messageStream)
     (async () => {
-        for await (const {event, url} of messageStream) {
-            const err = await database.addEvent(event)
-            if(err instanceof Error) {
-                console.log(err)
+        for await (const { event, url } of messageStream) {
+            const err = await database.addEvent(event);
+            if (err instanceof Error) {
+                console.log(err);
             }
         }
     })();

--- a/UI/app.tsx
+++ b/UI/app.tsx
@@ -128,10 +128,12 @@ async function initProfileSyncer(
     // );
     // database.syncEvents(_=>true, messageStream)
     (async () => {
-        for await (const { event, url } of messageStream) {
-            const err = await database.addEvent(event);
-            if (err instanceof Error) {
-                console.log(err);
+        for await (const msg of messageStream) {
+            if (msg.res.type == "EVENT") {
+                const err = await database.addEvent(msg.res.event);
+                if (err instanceof Error) {
+                    console.log(err);
+                }
             }
         }
     })();

--- a/UI/app_update.tsx
+++ b/UI/app_update.tsx
@@ -3,7 +3,7 @@ import { h } from "https://esm.sh/preact@10.17.1";
 import { getProfileEvent, getProfilesByName, ProfilesSyncer, saveProfile } from "../features/profile.ts";
 
 import { App } from "./app.tsx";
-import { AllUsersInformation, getGroupOf, getUserInfoFromPublicKey, UserInfo } from "./contact-list.ts";
+import { AllUsersInformation, getGroupOf, UserInfo } from "./contact-list.ts";
 
 import * as csp from "https://raw.githubusercontent.com/BlowaterNostr/csp/master/csp.ts";
 import { Database_Contextual_View } from "../database.ts";

--- a/UI/app_update.tsx
+++ b/UI/app_update.tsx
@@ -33,10 +33,11 @@ import { SignInEvent, signInWithExtension, signInWithPrivateKey } from "./signIn
 import {
     computeThreads,
     CustomAppData_Event,
+    Encrypted_Event,
     getTags,
     PinContact,
-    PlainText_Nostr_Event,
     Profile_Nostr_Event,
+    Text_Note_Event,
     UnpinContact,
 } from "../nostr.ts";
 import { MessageThread } from "./dm.tsx";
@@ -108,6 +109,9 @@ export async function* UI_Interaction_Update(args: {
                 if (ctx) {
                     console.log("sign in as", ctx.publicKey.bech32());
                     const dbView = await Database_Contextual_View.New(dexieDB, ctx);
+                    if (dbView instanceof Error) {
+                        throw dbView;
+                    }
                     const lamport = fromEvents(dbView.filterEvents((_) => true));
                     const app = new App(dbView, lamport, model, ctx, eventBus, pool, args.popOver);
                     const err = await app.initApp(ctx, pool);
@@ -503,7 +507,7 @@ export async function* Database_Update(
     while (true) {
         await csp.sleep(333);
         await changes.ready();
-        const changes_events: (PlainText_Nostr_Event | CustomAppData_Event | Profile_Nostr_Event)[] = [];
+        const changes_events: (Text_Note_Event | Encrypted_Event | Profile_Nostr_Event)[] = [];
         while (true) {
             if (!changes.isReadyToPop()) {
                 break;

--- a/UI/app_update.tsx
+++ b/UI/app_update.tsx
@@ -638,7 +638,7 @@ export async function* Relay_Update(
     ctx: NostrAccountContext,
 ) {
     for (;;) {
-        await csp.sleep(1000 * 1000000); // every 2.5 sec
+        await csp.sleep(1000 * 2.5); // every 2.5 sec
         console.log(`Relay: checking connections`);
         let changed = false;
         // first, remove closed relays

--- a/UI/app_update.tsx
+++ b/UI/app_update.tsx
@@ -32,7 +32,6 @@ import { ConnectionPool, RelayAlreadyRegistered } from "../lib/nostr-ts/relay.ts
 import { SignInEvent, signInWithExtension, signInWithPrivateKey } from "./signIn.tsx";
 import {
     computeThreads,
-    CustomAppData_Event,
     Encrypted_Event,
     getTags,
     PinContact,

--- a/UI/app_update.tsx
+++ b/UI/app_update.tsx
@@ -599,27 +599,27 @@ export async function* Database_Update(
             }
 
             // notification
-            {
-                const author = getUserInfoFromPublicKey(e.publicKey, allUserInfo.userInfos)?.profile;
-                if (e.pubkey != ctx.publicKey.hex && e.parsedTags.p.includes(ctx.publicKey.hex)) {
-                    notify(
-                        author?.profile.name ? author.profile.name : "",
-                        "new message",
-                        author?.profile.picture ? author.profile.picture : "",
-                        () => {
-                            const k = PublicKey.FromHex(e.pubkey);
-                            if (k instanceof Error) {
-                                console.error(k);
-                                return;
-                            }
-                            eventEmitter.emit({
-                                type: "SelectProfile",
-                                pubkey: k,
-                            });
-                        },
-                    );
-                }
-            }
+            // {
+            //     const author = getUserInfoFromPublicKey(e.publicKey, allUserInfo.userInfos)?.profile;
+            //     if (e.pubkey != ctx.publicKey.hex && e.parsedTags.p.includes(ctx.publicKey.hex)) {
+            //         notify(
+            //             author?.profile.name ? author.profile.name : "",
+            //             "new message",
+            //             author?.profile.picture ? author.profile.picture : "",
+            //             () => {
+            //                 const k = PublicKey.FromHex(e.pubkey);
+            //                 if (k instanceof Error) {
+            //                     console.error(k);
+            //                     return;
+            //                 }
+            //                 eventEmitter.emit({
+            //                     type: "SelectProfile",
+            //                     pubkey: k,
+            //                 });
+            //             },
+            //         );
+            //     }
+            // }
         }
         if (hasKind_1) {
             model.social.threads = getSocialPosts(database, allUserInfo.userInfos);

--- a/UI/app_update.tsx
+++ b/UI/app_update.tsx
@@ -449,6 +449,7 @@ export function getConversationMessages(args: {
     const msgs: MessageThread[] = [];
     for (const thread of threads) {
         const messages = convertEventsToChatMessages(thread, allUserInfo);
+        console.log(messages);
         if (messages.length > 0) {
             messages.sort((m1, m2) => {
                 if (m1.lamport && m2.lamport && m1.lamport != m2.lamport) {
@@ -459,6 +460,7 @@ export function getConversationMessages(args: {
             msgs.push({
                 root: messages[0],
                 replies: messages.slice(1),
+                // replies: [],
             });
         }
     }
@@ -520,15 +522,6 @@ export async function* Database_Update(
         }
 
         let hasKind_1 = false;
-        {
-            const events = [];
-            for (const e of changes_events) {
-                if (e.kind == NostrKind.CustomAppData) {
-                    events.push(e);
-                }
-            }
-            // await relayConfig.addEvents(events);
-        }
         for (let e of changes_events) {
             allUserInfo.addEvents([e]);
             const t = getTags(e).lamport_timestamp;

--- a/UI/app_update.tsx
+++ b/UI/app_update.tsx
@@ -638,7 +638,7 @@ export async function* Relay_Update(
     ctx: NostrAccountContext,
 ) {
     for (;;) {
-        await csp.sleep(1000 * 2.5); // every 2.5 sec
+        await csp.sleep(1000 * 1000000); // every 2.5 sec
         console.log(`Relay: checking connections`);
         let changed = false;
         // first, remove closed relays

--- a/UI/contact-list.ts
+++ b/UI/contact-list.ts
@@ -67,7 +67,7 @@ export class AllUsersInformation {
                     break;
                 case NostrKind.DIRECT_MESSAGE:
                     {
-                        console.log(event)
+                        console.log("all", event)
                         let whoAm_I_TalkingTo = "";
                         if (event.pubkey == this.ctx.publicKey.hex) {
                             // I am the sender

--- a/UI/contact-list.ts
+++ b/UI/contact-list.ts
@@ -5,9 +5,11 @@ import { NostrAccountContext, NostrEvent, NostrKind } from "../lib/nostr-ts/nost
 import {
     CustomAppData,
     CustomAppData_Event,
+    DirectedMessage_Event,
+    Encrypted_Event,
     getTags,
-    PlainText_Nostr_Event,
     Profile_Nostr_Event,
+    Text_Note_Event,
 } from "../nostr.ts";
 
 export interface UserInfo {
@@ -19,7 +21,7 @@ export interface UserInfo {
         readonly created_at: number;
         readonly content: CustomAppData;
     } | undefined;
-    events: PlainText_Nostr_Event[];
+    events: DirectedMessage_Event[];
 }
 
 export function getUserInfoFromPublicKey(k: PublicKey, users: Map<string, UserInfo>) {
@@ -32,7 +34,7 @@ export class AllUsersInformation {
 
     constructor(public readonly ctx: NostrAccountContext) {}
 
-    addEvents(events: (Profile_Nostr_Event | PlainText_Nostr_Event | CustomAppData_Event)[]) {
+    addEvents(events: (Profile_Nostr_Event | Text_Note_Event | Encrypted_Event)[]) {
         // const t = Date.now();
         for (const event of events) {
             switch (event.kind) {
@@ -63,12 +65,9 @@ export class AllUsersInformation {
                     break;
                 case NostrKind.TEXT_NOTE:
                     break;
-                case NostrKind.RECOMMED_SERVER:
-                    break;
-                case NostrKind.CONTACTS:
-                    break;
                 case NostrKind.DIRECT_MESSAGE:
                     {
+                        console.log(event)
                         let whoAm_I_TalkingTo = "";
                         if (event.pubkey == this.ctx.publicKey.hex) {
                             // I am the sender
@@ -140,8 +139,6 @@ export class AllUsersInformation {
                             this.userInfos.set(whoAm_I_TalkingTo, newUserInfo);
                         }
                     }
-                    break;
-                case NostrKind.DELETE:
                     break;
                 case NostrKind.CustomAppData: {
                     const obj = event.customAppData;

--- a/UI/contact-list.ts
+++ b/UI/contact-list.ts
@@ -67,7 +67,6 @@ export class AllUsersInformation {
                     break;
                 case NostrKind.DIRECT_MESSAGE:
                     {
-                        console.log("all", event);
                         let whoAm_I_TalkingTo = "";
                         if (event.pubkey == this.ctx.publicKey.hex) {
                             // I am the sender

--- a/UI/contact-list.ts
+++ b/UI/contact-list.ts
@@ -4,7 +4,6 @@ import { NostrAccountContext, NostrEvent, NostrKind } from "../lib/nostr-ts/nost
 
 import {
     CustomAppData,
-    CustomAppData_Event,
     DirectedMessage_Event,
     Encrypted_Event,
     getTags,

--- a/UI/contact-list.ts
+++ b/UI/contact-list.ts
@@ -67,7 +67,7 @@ export class AllUsersInformation {
                     break;
                 case NostrKind.DIRECT_MESSAGE:
                     {
-                        console.log("all", event)
+                        console.log("all", event);
                         let whoAm_I_TalkingTo = "";
                         if (event.pubkey == this.ctx.publicKey.hex) {
                             // I am the sender

--- a/UI/dexie-db.ts
+++ b/UI/dexie-db.ts
@@ -22,6 +22,10 @@ export class DexieDatabase extends dexie.Dexie implements EventsAdapter {
     async put(e: NostrEvent<NostrKind, Tag>): Promise<void> {
         this.events.put(e);
     }
+
+    async remove(id: string) {
+        this.events.delete(id)
+    }
 }
 
 export function NewIndexedDB(): DexieDatabase | Error {

--- a/UI/dexie-db.ts
+++ b/UI/dexie-db.ts
@@ -24,7 +24,7 @@ export class DexieDatabase extends dexie.Dexie implements EventsAdapter {
     }
 
     async remove(id: string) {
-        this.events.delete(id)
+        this.events.delete(id);
     }
 }
 

--- a/UI/dm.test.tsx
+++ b/UI/dm.test.tsx
@@ -19,6 +19,9 @@ import { fail } from "https://deno.land/std@0.176.0/testing/asserts.ts";
 
 const ctx = InMemoryAccountContext.New(PrivateKey.Generate());
 const database = await Database_Contextual_View.New(testEventsAdapter, ctx);
+if (database instanceof Error) {
+    fail(database.message);
+}
 const lamport = new LamportTime(0);
 
 const e = await database.addEvent(
@@ -26,7 +29,7 @@ const e = await database.addEvent(
         ["p", ctx.publicKey.hex],
     ], "hi") as NostrEvent,
 );
-if (!e) {
+if (!e || e instanceof Error) {
     fail();
 }
 

--- a/UI/dm.ts
+++ b/UI/dm.ts
@@ -1,9 +1,10 @@
 import { NostrEvent } from "../lib/nostr-ts/nostr.ts";
 import {
+    DirectedMessage_Event,
     getTags,
     groupImageEvents,
-    PlainText_Nostr_Event,
     reassembleBase64ImageFromEvents,
+    Text_Note_Event,
 } from "../nostr.ts";
 import { ChatMessage } from "./message.ts";
 import { PublicKey } from "../lib/nostr-ts/key.ts";
@@ -22,7 +23,7 @@ export type DM_Container_Model = {
 };
 
 export function convertEventsToChatMessages(
-    events: Iterable<PlainText_Nostr_Event>,
+    events: Iterable<DirectedMessage_Event>,
     userProfiles: Map<string, UserInfo>,
 ): ChatMessage[] {
     const messages: ChatMessage[] = [];

--- a/UI/dm.ts
+++ b/UI/dm.ts
@@ -45,7 +45,7 @@ export function convertEventsToChatMessages(
         }
         messages.push({
             event: textEvents[i],
-            content: textEvents[i].content,
+            content: textEvents[i].decryptedContent,
             type: "text",
             created_at: new Date(textEvents[i].created_at * 1000),
             lamport: getTags(textEvents[i]).lamport_timestamp,

--- a/UI/dm.ts
+++ b/UI/dm.ts
@@ -4,7 +4,6 @@ import {
     getTags,
     groupImageEvents,
     reassembleBase64ImageFromEvents,
-    Text_Note_Event,
 } from "../nostr.ts";
 import { ChatMessage } from "./message.ts";
 import { PublicKey } from "../lib/nostr-ts/key.ts";

--- a/UI/message-panel.tsx
+++ b/UI/message-panel.tsx
@@ -14,9 +14,11 @@ import { PublicKey } from "../lib/nostr-ts/key.ts";
 import { NostrEvent, NostrKind } from "../lib/nostr-ts/nostr.ts";
 import {
     CustomAppData_Event,
+    DirectedMessage_Event,
+    Encrypted_Event,
     PinContact,
-    PlainText_Nostr_Event,
     Profile_Nostr_Event,
+    Text_Note_Event,
     UnpinContact,
 } from "../nostr.ts";
 import { ProfileData, ProfilesSyncer } from "../features/profile.ts";
@@ -42,7 +44,7 @@ export type DirectMessagePanelUpdate =
     | ViewUserDetail
     | {
         type: "ViewEventDetail";
-        event: PlainText_Nostr_Event;
+        event: Text_Note_Event | DirectedMessage_Event;
     };
 
 export type ViewThread = {
@@ -465,7 +467,7 @@ function MessageBoxGroup(props: {
 }
 
 function MessageActions(
-    event: PlainText_Nostr_Event,
+    event: Text_Note_Event | DirectedMessage_Event,
     emit: emitFunc<ViewThread | DirectMessagePanelUpdate>,
 ) {
     return (
@@ -660,7 +662,7 @@ function ProfileCard(
 }
 
 function NoteCard(
-    event: Profile_Nostr_Event | PlainText_Nostr_Event | CustomAppData_Event,
+    event: Profile_Nostr_Event | Text_Note_Event | Encrypted_Event,
     eventEmitter: EventEmitter<ViewThread | ViewUserDetail>,
     allUserInfo: Map<string, UserInfo>,
 ) {

--- a/UI/message-thread-panel.tsx
+++ b/UI/message-thread-panel.tsx
@@ -17,7 +17,7 @@ import { getUserInfoFromPublicKey, UserInfo } from "./contact-list.ts";
 import { EventSyncer } from "./event_syncer.ts";
 import { Avatar } from "./components/avatar.tsx";
 import { ProfilesSyncer } from "../features/profile.ts";
-import { PlainText_Nostr_Event } from "../nostr.ts";
+import { DirectedMessage_Event, Text_Note_Event } from "../nostr.ts";
 import { ButtonGroup } from "./components/button-group.tsx";
 import { AboutIcon } from "./icons/about-icon.tsx";
 import { PrimaryTextColor } from "./style/colors.ts";
@@ -166,8 +166,8 @@ function MessageThreadBoxGroup(props: {
 }
 
 export function MessageThreadActions(
-    event: PlainText_Nostr_Event,
-    emit: emitFunc<{ type: "ViewEventDetail"; event: PlainText_Nostr_Event }>,
+    event: Text_Note_Event | DirectedMessage_Event,
+    emit: emitFunc<{ type: "ViewEventDetail"; event: Text_Note_Event | DirectedMessage_Event }>,
 ) {
     return (
         <ButtonGroup

--- a/UI/message.ts
+++ b/UI/message.ts
@@ -1,6 +1,6 @@
 import { PublicKey } from "../lib/nostr-ts/key.ts";
 import { MessageThread } from "./dm.tsx";
-import { PlainText_Nostr_Event } from "../nostr.ts";
+import { DirectedMessage_Event, Text_Note_Event } from "../nostr.ts";
 import { NoteID } from "../lib/nostr-ts/nip19.ts";
 
 export function* parseContent(content: string) {
@@ -88,7 +88,7 @@ export type ContentItem = {
 
 // Think of ChatMessage as an materialized view of NostrEvent
 export interface ChatMessage {
-    readonly event: PlainText_Nostr_Event;
+    readonly event: DirectedMessage_Event | Text_Note_Event;
     readonly type: "image" | "text";
     readonly created_at: Date;
     readonly lamport: number | undefined;

--- a/database.test.ts
+++ b/database.test.ts
@@ -3,12 +3,13 @@ import { Database_Contextual_View, EventsAdapter, Indices } from "./database.ts"
 import { prepareNormalNostrEvent } from "./lib/nostr-ts/event.ts";
 import { PrivateKey } from "./lib/nostr-ts/key.ts";
 import { InMemoryAccountContext, NostrEvent, NostrKind } from "./lib/nostr-ts/nostr.ts";
-import { assertEquals } from "https://deno.land/std@0.176.0/testing/asserts.ts";
+import { assertEquals, fail } from "https://deno.land/std@0.176.0/testing/asserts.ts";
 
 const ctx = InMemoryAccountContext.New(PrivateKey.Generate());
 
 Deno.test("Database", async () => {
     const db = await Database_Contextual_View.New(testEventsAdapter, ctx);
+    if (db instanceof Error) fail(db.message);
 
     const stream = db.subscribe();
     const event_to_add = await prepareNormalNostrEvent(ctx, 1, [], "1");

--- a/database.test.ts
+++ b/database.test.ts
@@ -1,8 +1,8 @@
 import { testEventsAdapter } from "./UI/_setup.test.ts";
-import { Database_Contextual_View, EventsAdapter, Indices } from "./database.ts";
+import { Database_Contextual_View } from "./database.ts";
 import { prepareNormalNostrEvent } from "./lib/nostr-ts/event.ts";
 import { PrivateKey } from "./lib/nostr-ts/key.ts";
-import { InMemoryAccountContext, NostrEvent, NostrKind } from "./lib/nostr-ts/nostr.ts";
+import { InMemoryAccountContext, NostrEvent } from "./lib/nostr-ts/nostr.ts";
 import { assertEquals, fail } from "https://deno.land/std@0.176.0/testing/asserts.ts";
 
 const ctx = InMemoryAccountContext.New(PrivateKey.Generate());

--- a/database.ts
+++ b/database.ts
@@ -98,7 +98,6 @@ export class Database_Contextual_View {
                     }
 
                     // add event to database and notify subscribers
-                    console.log("async load", parsedEvent);
                     db.events.push(parsedEvent);
                     await eventsAdapter.put(event);
                     /* not await */ db.sourceOfChange.put(parsedEvent);
@@ -474,7 +473,11 @@ async function originalEventToEncryptedEvent(
         }
         return _e;
     } else if (event.kind == NostrKind.DIRECT_MESSAGE) {
-        const decrypted = await ctx.decrypt(ctx.publicKey.hex, event.content);
+        const theOther = whoIamTalkingTo(event, ctx.publicKey);
+        if (theOther instanceof Error) {
+            return theOther;
+        }
+        const decrypted = await ctx.decrypt(theOther, event.content);
         if (decrypted instanceof Error) {
             return decrypted;
         }

--- a/database.ts
+++ b/database.ts
@@ -1,9 +1,7 @@
 import {
     CustomAppData,
     CustomAppData_Event,
-    DirectedMessage_Event,
     Encrypted_Event,
-    Encrypted_Kind,
     getTags,
     Profile_Nostr_Event,
     Tag,
@@ -12,16 +10,7 @@ import {
 import * as csp from "https://raw.githubusercontent.com/BlowaterNostr/csp/master/csp.ts";
 import { parseProfileData } from "./features/profile.ts";
 import { parseContent } from "./UI/message.ts";
-import {
-    DecryptionFailure,
-    decryptNostrEvent,
-    NostrAccountContext,
-    NostrEvent,
-    NostrKind,
-    RelayResponse_REQ_Message,
-    Tags,
-    verifyEvent,
-} from "./lib/nostr-ts/nostr.ts";
+import { NostrAccountContext, NostrEvent, NostrKind, Tags, verifyEvent } from "./lib/nostr-ts/nostr.ts";
 import { PublicKey } from "./lib/nostr-ts/key.ts";
 
 export const NotFound = Symbol("Not Found");

--- a/database.ts
+++ b/database.ts
@@ -59,13 +59,13 @@ export class Database_Contextual_View {
 
     static async New(eventsAdapter: EventsAdapter, ctx: NostrAccountContext) {
         const t = Date.now();
-        let kind4 = 0
+        let kind4 = 0;
         const allEvents = await eventsAdapter.filter((_) => {
-            if(_.kind == NostrKind.DIRECT_MESSAGE) {
-                kind4++
+            if (_.kind == NostrKind.DIRECT_MESSAGE) {
+                kind4++;
             }
-            return true
-        })
+            return true;
+        });
         console.log("Database_Contextual_View:onload", Date.now() - t, allEvents.length, kind4);
         const initialEvents = await loadInitialData(
             allEvents,
@@ -91,10 +91,9 @@ export class Database_Contextual_View {
         public readonly events: (Text_Note_Event | Encrypted_Event | Profile_Nostr_Event)[],
         private readonly ctx: NostrAccountContext,
     ) {
-        for  (const event of events) {
-            this.sourceOfChange.put(event)
+        for (const event of events) {
+            this.sourceOfChange.put(event);
         }
-
     }
 
     public readonly getEvent = async (keys: Indices): Promise<NostrEvent | undefined> => {
@@ -134,7 +133,6 @@ export class Database_Contextual_View {
         /* not await */ this.sourceOfChange.put(parsedEvent);
         return parsedEvent;
     }
-
 
     //////////////////
     // On DB Change //
@@ -240,30 +238,26 @@ export async function parseCustomAppDataEvent(
 async function loadInitialData(events: NostrEvent[], ctx: NostrAccountContext, eventsRemover: EventRemover) {
     const initialEvents: Accepted_Event[] = [];
     for await (const event of events) {
-
-            const pubkey = PublicKey.FromHex(event.pubkey);
-            if (pubkey instanceof Error) {
-                return pubkey;
-            }
-            const parsedEvent = await originalEventToParsedEvent(
-                {
-                    ...event,
-                    kind: event.kind,
-                },
-                ctx,
-                eventsRemover,
-            );
-            if (parsedEvent instanceof Error) {
-                console.error(parsedEvent)
-                continue
-            }
-            if (parsedEvent == false) {
-                continue;
-            }
-            // if(parsedEvent.kind == NostrKind.DIRECT_MESSAGE) {
-            //     console.log(parsedEvent)
-            // }
-            initialEvents.push(parsedEvent);
+        const pubkey = PublicKey.FromHex(event.pubkey);
+        if (pubkey instanceof Error) {
+            return pubkey;
+        }
+        const parsedEvent = await originalEventToParsedEvent(
+            {
+                ...event,
+                kind: event.kind,
+            },
+            ctx,
+            eventsRemover,
+        );
+        if (parsedEvent instanceof Error) {
+            console.error(parsedEvent);
+            continue;
+        }
+        if (parsedEvent == false) {
+            continue;
+        }
+        initialEvents.push(parsedEvent);
     }
     return initialEvents;
 }

--- a/database.ts
+++ b/database.ts
@@ -76,15 +76,21 @@ export class Database_Contextual_View {
             try {
                 let tt = 0;
                 for (const event of allEvents) {
-                    const pubkey = PublicKey.FromHex(event.pubkey)
-                    if(pubkey instanceof Error) {
-                        console.error(pubkey)
-                        continue
+                    const pubkey = PublicKey.FromHex(event.pubkey);
+                    if (pubkey instanceof Error) {
+                        console.error(pubkey);
+                        continue;
                     }
-                    const parsedEvent = await originalEventToEncryptedEvent(event, ctx, getTags(event), pubkey, eventsAdapter);
+                    const parsedEvent = await originalEventToEncryptedEvent(
+                        event,
+                        ctx,
+                        getTags(event),
+                        pubkey,
+                        eventsAdapter,
+                    );
                     if (parsedEvent instanceof Error) {
                         console.error(parsedEvent);
-                        await eventsAdapter.remove(event.id)
+                        await eventsAdapter.remove(event.id);
                         continue;
                     }
                     if (parsedEvent == false) {
@@ -92,14 +98,14 @@ export class Database_Contextual_View {
                     }
 
                     // add event to database and notify subscribers
-                    console.log("async load", parsedEvent)
+                    console.log("async load", parsedEvent);
                     db.events.push(parsedEvent);
                     await eventsAdapter.put(event);
                     /* not await */ db.sourceOfChange.put(parsedEvent);
                 }
                 console.log("Database_Contextual_View:transformEvent", tt);
             } catch (e) {
-                console.error(e)
+                console.error(e);
             }
         })();
 
@@ -153,11 +159,11 @@ export class Database_Contextual_View {
 
     syncEvents(
         filter: (e: NostrEvent) => boolean,
-        events: csp.Channel<{event: NostrEvent, url: string /*relay url*/}>,
+        events: csp.Channel<{ event: NostrEvent; url: string /*relay url*/ }>,
     ): csp.Channel<NostrEvent> {
         const resChan = csp.chan<NostrEvent>(buffer_size);
         (async () => {
-            for await (const {event, url} of events) {
+            for await (const { event, url } of events) {
                 if (resChan.closed()) {
                     await events.close(
                         "db syncEvents, resChan is closed, closing the source events",
@@ -167,8 +173,8 @@ export class Database_Contextual_View {
                 const e = event;
                 if (filter(e)) {
                     const res = await this.addEvent(e);
-                    if(res instanceof Error || res == false) {
-                        console.error(res)
+                    if (res instanceof Error || res == false) {
+                        console.error(res);
                     }
                 } else {
                     console.log(
@@ -467,7 +473,7 @@ async function originalEventToEncryptedEvent(
             return _e;
         }
         return _e;
-    } else if(event.kind == NostrKind.DIRECT_MESSAGE) {
+    } else if (event.kind == NostrKind.DIRECT_MESSAGE) {
         const decrypted = await ctx.decrypt(ctx.publicKey.hex, event.content);
         if (decrypted instanceof Error) {
             return decrypted;
@@ -481,5 +487,5 @@ async function originalEventToEncryptedEvent(
             parsedContentItems: Array.from(parseContent(event.content)),
         };
     }
-    return false
+    return false;
 }

--- a/features/dm.test.ts
+++ b/features/dm.test.ts
@@ -1,7 +1,7 @@
 import { fail } from "https://deno.land/std@0.176.0/testing/asserts.ts";
 import { testEventsAdapter } from "../UI/_setup.test.ts";
 import { Database_Contextual_View } from "../database.ts";
-import { PrivateKey, PublicKey } from "../lib/nostr-ts/key.ts";
+import { PrivateKey } from "../lib/nostr-ts/key.ts";
 import { InMemoryAccountContext } from "../lib/nostr-ts/nostr.ts";
 import { relays } from "../lib/nostr-ts/relay-list.test.ts";
 import { ConnectionPool } from "../lib/nostr-ts/relay.ts";
@@ -21,11 +21,7 @@ const messageStream = getAllEncryptedMessagesOf(
     ctx.publicKey,
     pool,
 );
-// database.syncNewDirectMessageEventsOf(
-//     accountContext,
-//     messageStream,
-// );
-// database.syncEvents(_=>true, messageStream)
+
 (async () => {
     for await (const msg of messageStream) {
         if (msg.res.type == "EVENT") {

--- a/features/dm.test.ts
+++ b/features/dm.test.ts
@@ -1,0 +1,38 @@
+import { fail } from "https://deno.land/std@0.176.0/testing/asserts.ts";
+import { testEventsAdapter } from "../UI/_setup.test.ts";
+import { Database_Contextual_View } from "../database.ts";
+import { PrivateKey, PublicKey } from "../lib/nostr-ts/key.ts";
+import { InMemoryAccountContext } from "../lib/nostr-ts/nostr.ts";
+import { relays } from "../lib/nostr-ts/relay-list.test.ts";
+import { ConnectionPool } from "../lib/nostr-ts/relay.ts";
+import { getAllEncryptedMessagesOf } from "./dm.ts";
+
+const ctx = InMemoryAccountContext.New(
+    PrivateKey.FromString("nsec16209kk73kp23e9huu08kd8af7jkw6t3uvvqdwzf3ez8c3yv8xf8srud5h5") as PrivateKey,
+);
+const pool = new ConnectionPool();
+pool.addRelayURLs(relays);
+const database = await Database_Contextual_View.New(testEventsAdapter, ctx);
+if (database instanceof Error) {
+    fail(database.message);
+}
+
+const messageStream = getAllEncryptedMessagesOf(
+    ctx.publicKey,
+    pool,
+);
+// database.syncNewDirectMessageEventsOf(
+//     accountContext,
+//     messageStream,
+// );
+// database.syncEvents(_=>true, messageStream)
+(async () => {
+    for await (const msg of messageStream) {
+        if (msg.res.type == "EVENT") {
+            const err = await database.addEvent(msg.res.event);
+            if (err instanceof Error) {
+                console.log(err);
+            }
+        }
+    }
+})();

--- a/features/dm.ts
+++ b/features/dm.ts
@@ -39,7 +39,6 @@ export async function sendDMandImages(args: {
             ],
             message,
         );
-        console.log("sendDMandImages:", nostrEvent);
         if (nostrEvent instanceof Error) {
             return nostrEvent;
         }

--- a/features/dm.ts
+++ b/features/dm.ts
@@ -121,7 +121,12 @@ async function* getAllEncryptedMessagesSendBy(
         throw resp;
     }
     for await (const nostrMessage of resp.chan) {
-        yield nostrMessage;
+        if(nostrMessage.res.type == "EVENT") {
+            yield {
+                event: nostrMessage.res.event,
+                url: nostrMessage.url
+            }
+        }
     }
 }
 
@@ -140,7 +145,12 @@ async function* getAllEncryptedMessagesReceivedBy(
         throw resp;
     }
     for await (const nostrMessage of resp.chan) {
-        yield nostrMessage;
+        if(nostrMessage.res.type == "EVENT") {
+            yield {
+                event: nostrMessage.res.event,
+                url: nostrMessage.url
+            }
+        }
     }
 }
 

--- a/features/dm.ts
+++ b/features/dm.ts
@@ -122,6 +122,7 @@ async function* getAllEncryptedMessagesSendBy(
     }
     for await (const nostrMessage of resp.chan) {
         if(nostrMessage.res.type == "EVENT") {
+            console.log("getAllEncryptedMessagesSendBy", nostrMessage)
             yield {
                 event: nostrMessage.res.event,
                 url: nostrMessage.url

--- a/features/dm.ts
+++ b/features/dm.ts
@@ -122,11 +122,7 @@ async function* getAllEncryptedMessagesSendBy(
     }
     for await (const nostrMessage of resp.chan) {
         if(nostrMessage.res.type == "EVENT") {
-            console.log("getAllEncryptedMessagesSendBy", nostrMessage)
-            yield {
-                event: nostrMessage.res.event,
-                url: nostrMessage.url
-            }
+            yield nostrMessage
         }
     }
 }
@@ -146,12 +142,7 @@ async function* getAllEncryptedMessagesReceivedBy(
         throw resp;
     }
     for await (const nostrMessage of resp.chan) {
-        if(nostrMessage.res.type == "EVENT") {
-            yield {
-                event: nostrMessage.res.event,
-                url: nostrMessage.url
-            }
-        }
+        yield nostrMessage
     }
 }
 

--- a/features/dm.ts
+++ b/features/dm.ts
@@ -121,9 +121,7 @@ async function* getAllEncryptedMessagesSendBy(
         throw resp;
     }
     for await (const nostrMessage of resp.chan) {
-        if(nostrMessage.res.type == "EVENT") {
-            yield nostrMessage
-        }
+        yield nostrMessage;
     }
 }
 
@@ -142,7 +140,7 @@ async function* getAllEncryptedMessagesReceivedBy(
         throw resp;
     }
     for await (const nostrMessage of resp.chan) {
-        yield nostrMessage
+        yield nostrMessage;
     }
 }
 


### PR DESCRIPTION
The previous implementation store decrypted kind 4 in indexed so that the loading is faster.
But this has 2 problems:
1. Security
Any one with access to your device can just open indexed db to see your DMs without knowing your private key
2. Programming Model inconsistency
The previous code treats kind-4 as if it's a plain text event and thus shares many logic with kind-1 which is problematic down the road.

This PR addressed this problem but broke the notification feature. Disable it for now.